### PR TITLE
port 5000 is unauthenticated, port 8971 is authenticated

### DIFF
--- a/frigate/docker-compose.yml.j2
+++ b/frigate/docker-compose.yml.j2
@@ -23,7 +23,7 @@ services:
         tmpfs:
           size: 1000000000
     ports:
-      - "5000:5000"
+      - "8971:8971"
       - "1935:1935" # RTMP feeds
     environment:
       FRIGATE_RTSP_PASSWORD: "{{ frigate_rtsp_password }}"


### PR DESCRIPTION
Official [documentation](https://docs.frigate.video/frigate/installation#ports) states:
- port 5000: Access to this port should be limited. 
- port 8971: Reverse proxies should use this port.